### PR TITLE
Registry passes context to Model

### DIFF
--- a/__tests__/registry.test.js
+++ b/__tests__/registry.test.js
@@ -10,26 +10,26 @@ describe('Registry', () => {
       expect(Registry.get('Test')).toBe(Test);
     });
 
-    test('sets the store on the class', () => {
+    test('sets the store on the class\'s context', () => {
       class Test2 {}
-      Registry.setStore(store);
+      Registry.store = store;
       Registry.register(Test2);
-      expect(Registry.get('Test2').store).toEqual(store);
+      expect(Registry.get('Test2').context.store).toEqual(store);
     });
   });
 
-  describe('.setStore()', () => {
+  describe('.store=', () => {
     const store = 'store2';
 
     test('sets the store on the Registry', () => {
-      Registry.setStore(store);
+      Registry.store = store;
       expect(Registry.store).toEqual(store);
     });
 
-    test('sets the store on registered models', () => {
-      Registry.setStore(store);
+    test('sets the store on registered models\' context', () => {
+      Registry.store = store;
       expect(Registry.store).toEqual(store);
-      expect(Registry.get('Test').store).toEqual(store);
+      expect(Registry.get('Test').context.store).toEqual(store);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@coverhound/eslint-config-coverhound": "^1.0.1",
     "babel-jest": "^19.0.0",
+    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "eslint": "^3.19.0",

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,25 +1,27 @@
-// should these even need to be within the module
-// or can they be part of the exported object?
-let store;
-const __registry__ = {};
+import 'babel-polyfill';
 
-const Registry = {
+class Registry {
+  constructor() {
+    this.__registry__ = {};
+    this.__context__ = {};
+  }
+
   get store() {
-    return store;
-  },
-  register(model) {
-    if (this.store) model.store = store;
-    __registry__[model.name] = model;
-  },
-  get(model) {
-    return __registry__[model];
-  },
-  setStore(newStore) {
-    store = newStore;
-    Object.values(__registry__).forEach(
-      (model) => model.store = newStore
-    );
-  },
-};
+    return this.__context__.store;
+  }
 
-export default Registry;
+  set store(store) {
+    this.__context__.store = store;
+  }
+
+  get(name) {
+    return this.__registry__[name];
+  }
+
+  register(model) {
+    model.context = this.__context__;
+    this.__registry__[model.name] = model;
+  }
+}
+
+export default new Registry();

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,6 +707,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-polyfill@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
+  dependencies:
+    babel-runtime "^6.22.0"
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
 babel-preset-es2015@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"


### PR DESCRIPTION
This PR does a few things:
1. Adds babel polyfill so that the registry tests pass on Node 6
2. Update the model to be a class
3. Change the internal behavior a little bit

This approach allows us to expand the things we want to inject into the Model. It also means that we can update the context object instead of needing to update all models, as that reference will get updated automatically.