### PR TITLE
Registry defines methods on models

### DIFF
--- a/__tests__/registry-e2e.test.js
+++ b/__tests__/registry-e2e.test.js
@@ -16,7 +16,6 @@ describe('Registry Integration', () => {
       }
     }
 
-    Article.__defineMethods__();
     Registry.register(Article);
     const RegisteredArticle = Registry.get('Article');
     subject = new RegisteredArticle(data);

--- a/src/registry.js
+++ b/src/registry.js
@@ -20,6 +20,7 @@ class Registry {
 
   register(model) {
     model.context = this.__context__;
+    model.__defineMethods__ && model.__defineMethods__();
     this.__registry__[model.name] = model;
   }
 }


### PR DESCRIPTION
I'm open to alternative implementations here. I feel like the Registry can call the setup for a model. If a model ever requires more setup than this, I'd suggest having something like `model#__init__()` to handle it