### PR TITLE
Proposal: Allow for overriding attribute names

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,8 +2,5 @@
   "presets": [
     "es2015",
     "stage-0",
-  ],
-  "plugins": [
-    "transform-decorators-legacy",
   ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ cache:
   directories:
   - ".eslintcache"
   - node_modules
+branches:
+  only:
+    - master
 script:
 - yarn run test:ci
 after_success: ./docs.sh

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@coverhound/eslint-config-coverhound": "^1.0.1",
     "babel-cli": "^6.24.1",
     "babel-jest": "^20.0.3",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "eslint": "^3.19.0",

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -32,11 +32,14 @@ import yup from 'yup';
  * const person = new Person(data);
  * person.employer => Promise<Company>
  * @param {string} resource JSON-API type of relationship
+ * @param {Object} options
+ * @param {string} options.name JSON-API name of the attribute
  */
-export const hasOne = (resource) => ({
+export const hasOne = (resource, { name } = {}) => ({
   type: 'relationship',
-  isArray: false,
   resource,
+  name,
+  isArray: false,
 });
 
 /**
@@ -69,11 +72,14 @@ export const hasOne = (resource) => ({
  * const person = new Person(data);
  * person.posts // => Promise<Array<Article>>
  * @param {string} resource JSON-API type of relationship
+ * @param {Object} options
+ * @param {string} options.name JSON-API name of the attribute
  */
-export const hasMany = (resource) => ({
+export const hasMany = (resource, { name } = {}) => ({
   type: 'relationship',
-  isArray: true,
   resource,
+  name,
+  isArray: true,
 });
 
 /**
@@ -92,10 +98,12 @@ export const hasMany = (resource) => ({
  * const blank = new Person({});
  * blank.name // => "Bob"
  * @param {Object} options
+ * @param {string} options.name JSON-API name of the attribute
  * @param {(string|function)} options.default Default value for this attribute
  */
-export const string = ({ default: defaultValue } = {}) => ({
+export const string = ({ name, default: defaultValue } = {}) => ({
   type: 'attribute',
+  name,
   cast: (obj) => yup.string().default(defaultValue).nullable().cast(obj),
 });
 
@@ -115,10 +123,12 @@ export const string = ({ default: defaultValue } = {}) => ({
  * const blank = new Person({});
  * blank.age // => 13
  * @param {Object} options
+ * @param {string} options.name JSON-API name of the attribute
  * @param {(number|function)} options.default Default value for this attribute
  */
-export const number = ({ default: defaultValue } = {}) => ({
+export const number = ({ name, default: defaultValue } = {}) => ({
   type: 'attribute',
+  name,
   cast: (obj) => yup.number().default(defaultValue).nullable().cast(obj),
 });
 
@@ -138,10 +148,12 @@ export const number = ({ default: defaultValue } = {}) => ({
  * const blank = new Person({});
  * blank.birthDate // => Date: [today]
  * @param {Object} options
+ * @param {string} options.name JSON-API name of the attribute
  * @param {(date|function)} options.default Default value for this attribute
  */
-export const date = ({ default: defaultValue } = {}) => ({
+export const date = ({ name, default: defaultValue } = {}) => ({
   type: 'attribute',
+  name,
   cast: (obj) => {
     if (obj === undefined) return defaultValue;
     if (obj === null) return obj;
@@ -156,7 +168,7 @@ export const date = ({ default: defaultValue } = {}) => ({
  * @example
  * class Person {
  *   static attributes = {
- *     isSubscribed: Attr.boolean({ default: true }),
+ *     isSubscribed: Attr.boolean({ name: 'is-subscribed', default: true }),
  *   };
  * }
  *
@@ -166,10 +178,12 @@ export const date = ({ default: defaultValue } = {}) => ({
  * const blank = new Person({});
  * blank.isSubscribed // => true
  * @param {Object} options
+ * @param {string} options.name JSON-API name of the attribute
  * @param {(boolean|function)} options.default Default value for this attribute
  */
-export const boolean = ({ default: defaultValue } = {}) => ({
+export const boolean = ({ name, default: defaultValue } = {}) => ({
   type: 'attribute',
+  name,
   cast: (obj) => (
     typeof obj === 'string' ?
       Boolean(obj) :
@@ -188,15 +202,17 @@ export const boolean = ({ default: defaultValue } = {}) => ({
  * }
  *
  * const person = new Person(data);
- * person.interests // => ["tennis", "squash"]
+ * person.interests // => ['tennis', 'squash']
  *
  * const blank = new Person({});
  * blank.interests // => []
  * @param {Object} options
+ * @param {string} options.name JSON-API name of the attribute
  * @param {(array|function)} options.default Default value for this attribute
  */
-export const array = () => ({
+export const array = ({ name } = {}) => ({
   type: 'attribute',
+  name,
   cast: (obj) => (Array.isArray(obj) ? obj : [obj]),
 });
 
@@ -206,7 +222,7 @@ export const array = () => ({
  * @example
  * class Person {
  *   static attributes = {
- *     isSubscribed: Attr.boolean({ default: {} }),
+ *     isSubscribed: Attr.boolean({ name: 'is-subscribed', default: {} }),
  *   };
  * }
  *
@@ -216,10 +232,12 @@ export const array = () => ({
  * const blank = new Person({});
  * blank.isSubscribed // => true
  * @param {Object} options
+ * @param {string} options.name JSON-API name of the attribute
  * @param {(object|function)} options.default Default value for this attribute
  */
-export const object = () => ({
+export const object = ({ name } = {}) => ({
   type: 'attribute',
+  name,
   cast: (obj) => (
     typeof obj === 'object' ? obj : {}
   ),

--- a/src/model.js
+++ b/src/model.js
@@ -14,7 +14,7 @@ const invalidAttribute = (field) => (
 const defineAttribute = (object, field, attribute) => {
   Object.defineProperty(object, field, {
     get() {
-      return attribute.cast(this.data.attributes[field]);
+      return attribute.cast(this.data.attributes[attribute.name || field]);
     }
   });
 };
@@ -22,7 +22,7 @@ const defineAttribute = (object, field, attribute) => {
 /**
  * @private
  */
-const defineRelationship = (object, field) => {
+const defineRelationship = (object, field, attribute) => {
   Object.defineProperty(object, field, {
     get() {
       const { isArray, resource } = this.constructor.attributes[field];
@@ -30,7 +30,7 @@ const defineRelationship = (object, field) => {
       if (!model) {
         throw new Error(`Unregistered model: ${resource}`);
       }
-      const data = this.data.relationships[field].data;
+      const data = this.data.relationships[attribute.name || field].data;
 
       return isArray
         ? Store.where({ id: data.map((d) => d.id) }, { model })
@@ -52,7 +52,7 @@ const defineMethods = (object, attributes) => {
         defineAttribute(object.prototype, field, attribute);
         break;
       case 'relationship':
-        defineRelationship(object.prototype, field);
+        defineRelationship(object.prototype, field, attribute);
         relationships[attribute.resource] = { key: field, ...attribute };
         break;
       default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,7 +455,7 @@ babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
 
-babel-plugin-syntax-decorators@^6.1.18, babel-plugin-syntax-decorators@^6.13.0:
+babel-plugin-syntax-decorators@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
 
@@ -519,14 +519,6 @@ babel-plugin-transform-class-properties@^6.24.1:
     babel-plugin-syntax-class-properties "^6.8.0"
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
-
-babel-plugin-transform-decorators-legacy@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators-legacy/-/babel-plugin-transform-decorators-legacy-1.3.4.tgz#741b58f6c5bce9e6027e0882d9c994f04f366925"
-  dependencies:
-    babel-plugin-syntax-decorators "^6.1.18"
-    babel-runtime "^6.2.0"
-    babel-template "^6.3.0"
 
 babel-plugin-transform-decorators@^6.24.1:
   version "6.24.1"
@@ -845,7 +837,7 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.2.0:
+babel-runtime@^6.18.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.25.0.tgz#33b98eaa5d482bb01a8d1aa6b437ad2b01aec41c"
   dependencies:
@@ -869,16 +861,6 @@ babel-template@^6.16.0, babel-template@^6.24.1:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-template@^6.3.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.25.0"
-    babel-types "^6.25.0"
-    babylon "^6.17.2"
-    lodash "^4.2.0"
-
 babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
@@ -893,20 +875,6 @@ babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.25.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.25.0"
-    babylon "^6.17.2"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
 babel-types@^6.18.0, babel-types@^6.23.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
@@ -916,7 +884,7 @@ babel-types@^6.18.0, babel-types@^6.23.0, babel-types@^6.24.1:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel-types@^6.19.0, babel-types@^6.25.0:
+babel-types@^6.19.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
@@ -928,10 +896,6 @@ babel-types@^6.19.0, babel-types@^6.25.0:
 babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0, babylon@^6.17.0:
   version "6.17.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
-
-babylon@^6.17.2:
-  version "6.17.4"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
 babylon@~7.0.0-beta.16:
   version "7.0.0-beta.18"


### PR DESCRIPTION
This will allow us to have camelCase names everywhere. Example:

```js
const jsonApiData = {
  attributes: {
    'is-subscribed': false,
    'first-name': 'Bernardo',
  }
};

AR.define('people', class Person {
  static attributes = {
    isSubscribed: Attr.boolean({ name: 'is-subscribed' }),
    firstName: Attr.string({ name: 'first-name' }),
  };
});
```

How we'd have to have done it before:

```js
AR.define('people', class Person {
  static attributes = {
    'is-subscribed': Attr.boolean(),
    'first-name': Attr.string()
  };

  get isSubscribed() { return this['is-subscribed']; }
  get firstName() { return this['first-name']; }
});
```

Alternatively, the API could be reversed so that the key is ALWAYS the JSON-API value and the `name` in the object is the method name. I'm fine with either. I could see the argument for this implementation given that the other argument, `default`, is something that only the model knows about.

Example:

```js
AR.define('people', class Person {
  static attributes = {
    'is-subscribed': Attr.boolean({ name: 'isSubscribed' }),
    'first-name': Attr.string({ name: 'firstName' })
  };
});
```