### PR TITLE
Add functionality to update reverse relationship

### DIFF
--- a/__tests__/api/__snapshots__/api.test.js.snap
+++ b/__tests__/api/__snapshots__/api.test.js.snap
@@ -1,18 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reducer actions apiConfigure() updates the apiConfig key 1`] = `
-Object {
-  "apiConfig": Object {
-    "baseUrl": "http://coverhound.com/api",
-  },
-  "isCreating": 0,
-  "isDeleting": 0,
-  "isReading": 0,
-  "isUpdating": 0,
-  "resources": Object {},
-}
-`;
-
 exports[`reducer actions apiClear() clears the resource 1`] = `
 Object {
   "apiConfig": Object {},
@@ -23,6 +10,19 @@ Object {
   "resources": Object {
     "people": Object {},
   },
+}
+`;
+
+exports[`reducer actions apiConfigure() updates the apiConfig key 1`] = `
+Object {
+  "apiConfig": Object {
+    "baseUrl": "http://coverhound.com/api",
+  },
+  "isCreating": 0,
+  "isDeleting": 0,
+  "isReading": 0,
+  "isUpdating": 0,
+  "resources": Object {},
 }
 `;
 
@@ -192,11 +192,6 @@ Object {
   "isUpdating": 0,
   "resources": Object {
     "people": Object {
-      "2": Object {
-        "attributes": Object {
-          "name": "Yangster",
-        },
-      },
       "5": Object {
         "attributes": Object {
           "age": 25,

--- a/__tests__/api/__snapshots__/utils.test.js.snap
+++ b/__tests__/api/__snapshots__/utils.test.js.snap
@@ -1,0 +1,206 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Utils createReverseRelationships() updates hasMany relationships 1`] = `
+Object {
+  "comments": Object {
+    "data": Array [
+      Object {
+        "id": "12",
+        "type": "comments",
+      },
+      Object {
+        "id": "5",
+        "type": "comments",
+      },
+    ],
+  },
+}
+`;
+
+exports[`Utils mergeResources() adds included resources 1`] = `
+Object {
+  "resources": Object {
+    "comments": Object {
+      "5": Object {
+        "attributes": Object {
+          "body": "First!",
+        },
+        "id": "5",
+        "links": Object {
+          "self": "http://example.com/comments/5",
+        },
+        "relationships": Object {
+          "author": Object {
+            "data": Object {
+              "id": "9",
+              "type": "people",
+            },
+          },
+        },
+        "type": "comments",
+      },
+    },
+    "people": Object {
+      "9": Object {
+        "attributes": Object {
+          "address": Object {
+            "road": "123 Main St",
+          },
+          "first-name": "Dan",
+          "last-name": "Gebhardt",
+          "twitter": "dgeb",
+        },
+        "id": "9",
+        "links": Object {
+          "self": "http://example.com/people/9",
+        },
+        "relationships": Object {
+          "comments": Object {
+            "data": Array [
+              Object {
+                "id": "5",
+                "type": "comments",
+              },
+              Object {
+                "id": "12",
+                "type": "comments",
+              },
+              Object {
+                "id": "5",
+                "type": "comments",
+              },
+              Object {
+                "id": "5",
+                "type": "comments",
+              },
+            ],
+          },
+        },
+        "type": "people",
+      },
+    },
+  },
+}
+`;
+
+exports[`Utils mergeResources() adds multiple resources 1`] = `
+Object {
+  "resources": Object {
+    "comments": Object {
+      "5": Object {
+        "attributes": Object {
+          "body": "First!",
+        },
+        "id": "5",
+        "links": Object {
+          "self": "http://example.com/comments/5",
+        },
+        "relationships": Object {
+          "author": Object {
+            "data": Object {
+              "id": "9",
+              "type": "people",
+            },
+          },
+        },
+        "type": "comments",
+      },
+    },
+    "people": Object {
+      "9": Object {
+        "attributes": Object {
+          "address": Object {
+            "road": "123 Main St",
+          },
+          "first-name": "Dan",
+          "last-name": "Gebhardt",
+          "twitter": "dgeb",
+        },
+        "id": "9",
+        "links": Object {
+          "self": "http://example.com/people/9",
+        },
+        "relationships": Object {
+          "comments": Object {
+            "data": Array [
+              Object {
+                "id": "5",
+                "type": "comments",
+              },
+              Object {
+                "id": "12",
+                "type": "comments",
+              },
+              Object {
+                "id": "5",
+                "type": "comments",
+              },
+            ],
+          },
+        },
+        "type": "people",
+      },
+    },
+  },
+}
+`;
+
+exports[`Utils mergeResources() adds singular resources 1`] = `
+Object {
+  "resources": Object {
+    "comments": Object {
+      "12": Object {
+        "relationships": Object {
+          "author": Object {
+            "data": Object {
+              "id": "9",
+              "type": "people",
+            },
+          },
+        },
+      },
+      "5": Object {
+        "relationships": Object {
+          "author": Object {
+            "data": Object {
+              "id": "9",
+              "type": "people",
+            },
+          },
+        },
+      },
+    },
+    "people": Object {
+      "9": Object {
+        "attributes": Object {
+          "address": Object {
+            "road": "123 Main St",
+          },
+          "first-name": "Dan",
+          "last-name": "Gebhardt",
+          "twitter": "dgeb",
+        },
+        "id": "9",
+        "links": Object {
+          "self": "http://example.com/people/9",
+        },
+        "relationships": Object {
+          "comments": Object {
+            "data": Array [
+              Object {
+                "id": "5",
+                "type": "comments",
+              },
+              Object {
+                "id": "12",
+                "type": "comments",
+              },
+            ],
+          },
+        },
+        "type": "people",
+      },
+    },
+  },
+}
+`;

--- a/src/api/reducer.js
+++ b/src/api/reducer.js
@@ -20,10 +20,6 @@ const initialState = {
   isDeleting: 0,
 };
 
-const updateResources = (state, resources) => (
-  imm.set(state, 'resources', mergeResources(state.resources, resources))
-);
-
 /**
  * API Reducer
  * @alias module:active-redux/api.reducer
@@ -36,14 +32,14 @@ export default createReducer({
     clearResources(state, type)
   ),
   [Types.API_HYDRATE]: (state, { payload: resources }) => (
-    updateResources(state, resources)
+    mergeResources(state, resources)
   ),
 
   [Types.API_WILL_CREATE]: (state) => (
     incrementProperty(state, 'isCreating')
   ),
   [Types.API_CREATE_DONE]: (state, { payload: resources }) => {
-    const newState = updateResources(state, resources);
+    const newState = mergeResources(state, resources);
     return decrementProperty(newState, 'isCreating');
   },
   [Types.API_CREATE_FAILED]: (state) => (
@@ -54,7 +50,7 @@ export default createReducer({
     incrementProperty(state, 'isReading')
   ),
   [Types.API_READ_DONE]: (state, { payload: resources }) => {
-    const newState = updateResources(state, resources);
+    const newState = mergeResources(state, resources);
     return decrementProperty(newState, 'isReading');
   },
   [Types.API_READ_FAILED]: (state) => (
@@ -66,7 +62,7 @@ export default createReducer({
     return markPendingResources(newState, resources);
   },
   [Types.API_UPDATE_DONE]: (state, { payload: resources }) => {
-    const newState = updateResources(state, resources);
+    const newState = mergeResources(state, resources);
     return decrementProperty(newState, 'isUpdating');
   },
   [Types.API_UPDATE_FAILED]: (state) => (

--- a/src/api/utils/index.js
+++ b/src/api/utils/index.js
@@ -1,31 +1,118 @@
+import 'babel-polyfill';
 import imm from 'object-path-immutable';
+import Registry from '../../registry';
 
 export apiClient from './api-client';
 
+/**
+ * @module
+ * @private
+ */
+
+/**
+ * @example
+ * incrementProperty(state, 'isReading')
+ * @param {Object} state Object on which the key is incremented
+ * @param {string} key Key to increment
+ */
 export const incrementProperty = (state, key) => (
   imm.set(state, key, state[key] + 1)
 );
 
+/**
+ * @example
+ * decrementProperty(state, 'isReading')
+ * @param {Object} state Object on which the key is decremented
+ * @param {string} key Key to decrement
+ */
 export const decrementProperty = (state, key) => (
   imm.set(state, key, state[key] - 1)
 );
 
-export const resourcesArray = (data) => (
+/**
+ * @param {Array|Object} data
+ */
+export const resourcesArray = (data = []) => (
   Array.isArray(data) ? data : [data]
 );
 
+/**
+ * @example
+ * const obj = { foo: bar: { baz: 'hi' } }
+ * getProperty(obj, 'foo', 'bar', 'baz') // => 'hi'
+ * getProperty(obj, 'a', 'b', 'c') // => undefined
+ *
+ * @param {Object} object Object to traverse
+ * @param {String[]} keys Keys to look up
+ */
+export const getProperty = (object, ...keys) => (
+  keys.reduce((acc, key) => {
+    if (acc === undefined) return acc;
+    return acc[key];
+  }, object)
+);
+
+/**
+ * Creates reverse relationships for data merged into the state
+ * @param {Object} state
+ * @param {Object} newState Immutable Object via object-path-immutable
+ * @param {Object} data JSON-API data object
+ * @param {Object} data.id
+ * @param {Object} data.type
+ * @param {Object} data.relationships
+ */
+export const createReverseRelationships = (state, newState, { id, type, relationships = {} }) => {
+  Object.values(relationships).forEach(({ data }) => {
+    const children = resourcesArray(data);
+    const childModel = Registry.get(children[0].type);
+    const childData = { type, id };
+    const { key, isArray } = childModel.relationships[type];
+
+    children.forEach(({ type: relType, id: relId }) => {
+      const objectPath = ['resources', relType, relId, 'relationships', key];
+      const existingRelationships = resourcesArray(getProperty(state, ...objectPath));
+
+      if (!isArray) {
+        newState.set([...objectPath, 'data'], childData);
+        return;
+      }
+
+      if (existingRelationships.find((relationship) => relationship.id === id)) return;
+
+      newState.push([...objectPath, 'data'], childData);
+    });
+  });
+};
+
+/**
+ * Merges all resources into the state
+ * @param {Object} state
+ * @param {Object} payload JSON-API payload
+ * @param {Object} payload.data
+ * @param {Object} payload.included
+ */
 export const mergeResources = (state, { data, included = [] }) => {
   const newState = imm(state);
 
   resourcesArray(data).concat(included).forEach((dataObj) => {
     // if we don't do this and the ID is a number, it'll create an array
-    newState.set(dataObj.type, state[dataObj.type] || {});
-    newState.set(`${dataObj.type}.${dataObj.id}`, dataObj);
+    newState.set(['resources', dataObj.type], state[dataObj.type] || {});
+    newState.set(['resources', dataObj.type, dataObj.id], dataObj);
+    createReverseRelationships(state, newState, dataObj);
   });
 
   return newState.value();
 };
 
+/**
+ * This function clears differently based on what's passed in
+ * Object: { type, id } -> this resource is cleared
+ * Array: Each of the resources is cleared
+ * String: '[type]' -> These resources are cleared
+ * undefined: -> All resources are cleared
+ * @param {Object} state
+ * @param {Object[]|Object|string|undefined} data
+ */
 export const clearResources = (state, data) => {
   switch (typeof data) {
     case 'object': {
@@ -39,22 +126,31 @@ export const clearResources = (state, data) => {
   }
 };
 
+/**
+ * @example
+ * const CUSTOM_REDUX_ACTION = 'CUSTOM_REDUX_ACTION';
+ * export const customReduxAction = createAction(CUSTOM_REDUX_ACTION); // => [function]
+ * customReduxAction(payload) // => { type, payload }
+ * @param {string} type Action type
+ */
 export const createAction = (type) => (payload) => ({ type, payload });
 
+/**
+ * @param {Object} mappings Reducer handlers per action
+ * @param {Object} initialState
+ */
 export const createReducer = (mappings, initialState) => (state = initialState, action) => (
   mappings[action.type] ? mappings[action.type](state, action) : state
 );
 
-export const hasProperty = (object, ...keys) => (
-  keys.reduce((acc, key) => {
-    if (acc === undefined) return acc;
-    return acc[key];
-  }, object)
-);
-
+/**
+ * @param {Object} state
+ * @param {Object} resource
+ * @param {Array|Object} resource.data
+ */
 export const markPendingResources = (state, { data }) => (
   resourcesArray(data).reduce((acc, resource) => {
-    if (!hasProperty(state, 'resources', resource.type, resource.id)) return acc;
+    if (!getProperty(state, 'resources', resource.type, resource.id)) return acc;
     return acc.set(['resources', resource.type, resource.id, 'isPending'], true);
   }, imm(state)).value()
 );


### PR DESCRIPTION
Contains commits from https://github.com/coverhound/active-redux/pull/23

Closes #9

When a resource is merged, it's possible that it will have one-sided
relationships. We're a good friend of this resource, and we think it
deserves to be happy, so we're going to inform the other parties of their
relationship status.

Example:

```js
/*
 * We now have Person number 5 in our store. Like Mourinho after a tough
 * match, it has no comments.
 */
Person.find(5);

/*
 * When we create a comment for the person above, the information we get
 * back will indicate that the comment belongs to the person
 */
dispatch(createComment(data));

/*
 * When we query the store now, person number 5 has comments.
 * There is much rejoicing.
 */
Person.find(5)
```