### PR TITLE
Remove babel-polyfill dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   },
   "dependencies": {
     "axios": "^0.16.1",
-    "babel-polyfill": "^6.23.0",
     "object-path-immutable": "^0.5.0",
+    "object.entries": "^1.0.4",
+    "object.values": "^1.0.4",
     "yup": "^0.21.3"
   },
   "devDependencies": {

--- a/src/api/utils/index.js
+++ b/src/api/utils/index.js
@@ -1,6 +1,6 @@
-import 'babel-polyfill';
 import imm from 'object-path-immutable';
 import Registry from '../../registry';
+import '../../polyfill';
 
 export apiClient from './api-client';
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import 'babel-polyfill';
-
 import Store from './store';
 import define from './model';
 

--- a/src/model.js
+++ b/src/model.js
@@ -1,3 +1,4 @@
+import './polyfill';
 import Store from './store';
 import Registry from './registry';
 

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,0 +1,5 @@
+import values from 'object.values';
+import entries from 'object.entries';
+
+if (!Object.values) values.shim();
+if (!Object.entries) entries.shim();

--- a/src/store.js
+++ b/src/store.js
@@ -1,3 +1,4 @@
+import './polyfill';
 import { remoteRead } from './api';
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1273,6 +1273,16 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.6.1:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.0.tgz#3b00385e85729932beffa9163bbea1234e932914"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
 es-abstract@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
@@ -2047,7 +2057,7 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
-is-regex@^1.0.3:
+is-regex@^1.0.3, is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
@@ -2742,12 +2752,30 @@ object.assign@^4.0.4:
     function-bind "^1.1.0"
     object-keys "^1.0.10"
 
+object.entries@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
+
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+object.values@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Just use the two polyfills that we need - `Object#values` and `Object#entries`