### PR TITLE
Active Redux fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "license": "MIT",
   "scripts": {
     "babel": "babel src --out-dir dist",
-    "build": "rm -rf dist && npm run babel",
+    "dist": "rm -rf dist && npm run babel",
     "dev": "npm run babel -- -w",
     "lint": "eslint src",
     "docs": "jsdoc -c .jsdoc.json",
-    "postinstall": "npm run build",
+    "postinstall": "npm run dist",
     "test": "jest",
     "test:ci": "jest --ci",
     "test:coverage": "jest --coverage",

--- a/src/model.js
+++ b/src/model.js
@@ -101,6 +101,8 @@ export const parseParams = (context, string) => {
 export default function define(type, model = class {}) {
   /**
    * Active Redux Model
+   * @property {String|Number} id JSON-API Resource ID
+   * @property {String} type JSON-API Resource Type
    */
   const Model = class extends model {
 
@@ -112,6 +114,7 @@ export default function define(type, model = class {}) {
 
     /**
     * Attributes of a model, for which methods will be defined
+    * @see {@link module:active-redux/attributes}
     * @example
     * import { Attr, define } from 'active-redux';
     *
@@ -197,21 +200,18 @@ export default function define(type, model = class {}) {
       return this.constructor.endpoint(action, this);
     }
 
+    /**
+     * @param {Object} data JSON-API data
+     */
     constructor(data) {
       super(data);
       this.data = data;
     }
 
-    /**
-     * @return {string} JSON-API Resource ID
-     */
     get id() {
       return this.data.id;
     }
 
-    /**
-     * @return {string} JSON-API Resource Type
-     */
     get type() {
       return this.constructor.type;
     }


### PR DESCRIPTION
This PR stops active-redux from running stuff on install. I did not realize at the time of originally writing this plugin that `"build"` is a reserved npm script that runs upon install. I've renamed that script to `"dist"` instead.

Also contains some documentation improvements.