### PR TITLE
Fix bugs found by setting up Active-Redux

### DIFF
--- a/src/api/utils/index.js
+++ b/src/api/utils/index.js
@@ -66,7 +66,11 @@ export const createReverseRelationships = (state, newState, { id, type, relation
     if (!data) return;
 
     const children = resourcesArray(data);
+    if (children.length === 0) return;
+
     const childModel = Registry.get(children[0].type);
+    if (!childModel) return;
+
     const childData = { type, id };
     if (!childModel.relationships[type]) return;
 

--- a/src/model.js
+++ b/src/model.js
@@ -31,7 +31,7 @@ const defineRelationship = (object, field, attribute) => {
   Object.defineProperty(object, field, {
     get() {
       const find = ({ id } = {}) => Registry.get(resource).peek(id);
-      const fetch = (isArray ? (data = []) => data.map(find) : find);
+      const fetch = (isArray ? (data = []) => data.map(find).filter(Boolean) : find);
       const data = this.data.relationships[key].data;
       return fetch(data);
     }

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -142,19 +142,22 @@ export default class QueryProxy {
     this.__query(query, { endpoint }).then(this.map)
   );
 
-  __selectQuery = (query, { endpoint } = {}) => createSelector(
-    (state) => state[namespace.value].indices[endpoint],
-    (state) => state[namespace.value].resources[this.resource],
-    (index = []) => {
-      const results = index.map(({ id }) => this.peek(id));
-      results.isFetching = index.isFetching;
-      return results;
-    },
-  );
-  __selectQueryPromise = (query, { endpoint } = {}) => {
+  __selectQuery = (query, { endpoint = this.model.endpoint('read') } = {}) => {
+    const hash = generateEndpoint(endpoint, query);
+    return createSelector(
+      (state) => state[namespace.value].indices[hash],
+      (state) => state[namespace.value].resources[this.resource],
+      (index = []) => {
+        const results = index.map(({ id }) => this.peek(id));
+        results.isFetching = index.isFetching;
+        return results;
+      },
+    );
+  };
+  __selectQueryPromise = (query, { endpoint = this.model.endpoint('read') } = {}) => {
     const promise = this.query(query, { endpoint });
     this.store.dispatch(apiIndexAsync({
-      hash: endpoint,
+      hash: generateEndpoint(endpoint, query),
       promise,
     }));
     return promise;

--- a/src/query/utils.js
+++ b/src/query/utils.js
@@ -46,7 +46,7 @@ export const createQuerySelector = (promise, selector) => createDeepEqualSelecto
   }
 );
 
-export const generateEndpoint = (endpoint, query) => {
+export const generateEndpoint = (endpoint = '', query = '') => {
   let queryString = query;
   if (typeof query !== 'string') {
     queryString = qs.stringify(query);


### PR DESCRIPTION
In this PR:

**Model.[plural-relationship] filters out null values**

You would expect `Person.comments` to return comments - and zero `null` values, regardless of whether the values exist in the store.

This can happen if you have a resource that wasn't bundled with its relationships.

**Add guard clauses to improve consistency**

`createReverseRelationships` didn't account for:

1. The registry returning nothing if a model wasn't found
2. The array of relationships being empty

This fixes those cases.